### PR TITLE
extraDependencies didn't really work, exiting with error at package time

### DIFF
--- a/tomcat7-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat7/run/AbstractExecWarMojo.java
+++ b/tomcat7-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat7/run/AbstractExecWarMojo.java
@@ -209,7 +209,7 @@ public abstract class AbstractExecWarMojo
      *
      * @parameter
      */
-    private List<Dependency> extraDependencies;
+    private List<ExtraDependency> extraDependencies;
 
     /**
      * Main class to use for starting the standalone jar.
@@ -378,26 +378,30 @@ public abstract class AbstractExecWarMojo
             // add extra dependencies
             if ( extraDependencies != null && !extraDependencies.isEmpty() )
             {
-                for ( Dependency dependency : extraDependencies )
+                for ( ExtraDependency extraDependency : extraDependencies )
                 {
-                    // String groupId, String artifactId, String version, String scope, String type
-                    Artifact artifact =
-                        artifactFactory.createArtifact( dependency.getGroupId(), dependency.getArtifactId(),
-                                                        dependency.getVersion(), dependency.getScope(),
-                                                        dependency.getType() );
+					if ( extraDependency.dependency != null )
+					{
+		                    Dependency dependency = extraDependency.dependency;
+				            // String groupId, String artifactId, String version, String scope, String type
+				            Artifact artifact =
+				                artifactFactory.createArtifact( dependency.getGroupId(), dependency.getArtifactId(),
+				                                                dependency.getVersion(), dependency.getScope(),
+				                                                dependency.getType() );
 
-                    artifactResolver.resolve( artifact, this.remoteRepos, this.local );
-                    JarFile jarFile = new JarFile( artifact.getFile() );
-                    Enumeration<JarEntry> jarEntries = jarFile.entries();
-                    while ( jarEntries.hasMoreElements() )
-                    {
-                        JarEntry jarEntry = jarEntries.nextElement();
-                        InputStream jarEntryIs = jarFile.getInputStream( jarEntry );
+				            artifactResolver.resolve( artifact, this.remoteRepos, this.local );
+				            JarFile jarFile = new JarFile( artifact.getFile() );
+				            Enumeration<JarEntry> jarEntries = jarFile.entries();
+				            while ( jarEntries.hasMoreElements() )
+				            {
+				                JarEntry jarEntry = jarEntries.nextElement();
+				                InputStream jarEntryIs = jarFile.getInputStream( jarEntry );
 
-                        os.putArchiveEntry( new JarArchiveEntry( jarEntry.getName() ) );
-                        IOUtils.copy( jarEntryIs, os );
-                        os.closeArchiveEntry();
-                    }
+				                os.putArchiveEntry( new JarArchiveEntry( jarEntry.getName() ) );
+				                IOUtils.copy( jarEntryIs, os );
+				                os.closeArchiveEntry();
+				            }
+					}
                 }
             }
 

--- a/tomcat7-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat7/run/ExtraDependency.java
+++ b/tomcat7-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat7/run/ExtraDependency.java
@@ -1,0 +1,39 @@
+package org.apache.tomcat.maven.plugin.tomcat7.run;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.model.Dependency;
+
+import java.io.File;
+
+/**
+ * @author William Ghelfi <trumbitta@gmail.com>
+ * @since 2.0
+ */
+public class ExtraDependency
+{
+
+    public Dependency dependency;
+
+    public ExtraDependency()
+    {
+        // no op
+    }
+
+}


### PR DESCRIPTION
Hello, 
following the instructions here: http://tomcat.apache.org/maven-plugin-2.0-SNAPSHOT/executable-war-jar.html

at mvn clean package I was obtaining a ClassNotFound stating that org.apache.tomcat.maven.plugin.tomcat7.run.ExtraDependency didn't exist

so I hacked around this solution that works for me
