### PR TITLE
Add skip configuration option

### DIFF
--- a/tomcat7-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat7/run/AbstractExecWarMojo.java
+++ b/tomcat7-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat7/run/AbstractExecWarMojo.java
@@ -103,6 +103,12 @@ public abstract class AbstractExecWarMojo
                 defaultValue = "${project.artifactId}-${project.version}-war-exec.jar", required = true )
     protected String finalName;
 
+	/**
+     * Skip the execution
+     */
+    @Parameter( property = "maven.tomcat.skip", defaultValue = "false" )
+    private boolean skip;
+
     /**
      * The webapp context path to use for the web application being run.
      * The name to store webapp in exec jar. Do not use /
@@ -200,7 +206,9 @@ public abstract class AbstractExecWarMojo
     public void execute()
         throws MojoExecutionException, MojoFailureException
     {
-
+		if (this.skip) {
+			return;
+		}
         //project.addAttachedArtifact(  );
         File warExecFile = new File( buildDirectory, finalName );
         if ( warExecFile.exists() )


### PR DESCRIPTION
The "skip" parameter allows developers to skip mojo execution for "exec-war" and "exec-war-only" goals
