### PR TITLE
Fix for MTOMCAT-177 - tomcat7:deploy ignores proxy settings

### DIFF
--- a/common-tomcat-maven-plugin/src/main/java/org/apache/tomcat/maven/common/deployer/TomcatManager.java
+++ b/common-tomcat-maven-plugin/src/main/java/org/apache/tomcat/maven/common/deployer/TomcatManager.java
@@ -178,7 +178,6 @@ public class TomcatManager
 
             String host = url.getHost();
             int port = url.getPort() > -1 ? url.getPort() : AuthScope.ANY_PORT;
-
             httpClient.getCredentialsProvider().setCredentials( new AuthScope( host, port ), creds );
 
             AuthCache authCache = new BasicAuthCache();
@@ -272,7 +271,6 @@ public class TomcatManager
      */
     private void applyProxy() {
     	if( this.proxy != null ) {
-    		System.out.println("proxy: " + proxy);
     		HttpHost proxy = new HttpHost(this.proxy.getHost(), this.proxy.getPort(), this.proxy.getProtocol());
     		httpClient.getParams().setParameter( ConnRoutePNames.DEFAULT_PROXY, proxy );
     		if( this.proxy.getUsername() != null ) {

--- a/tomcat6-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat6/AbstractCatalinaMojo.java
+++ b/tomcat6-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat6/AbstractCatalinaMojo.java
@@ -20,9 +20,11 @@ package org.apache.tomcat.maven.plugin.tomcat6;
  */
 
 import org.apache.maven.artifact.manager.WagonManager;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.settings.Proxy;
 import org.apache.maven.wagon.authentication.AuthenticationInfo;
 import org.apache.tomcat.maven.common.deployer.TomcatManager;
 import org.apache.tomcat.maven.common.deployer.TomcatManagerException;
@@ -69,6 +71,12 @@ public abstract class AbstractCatalinaMojo
      */
     @Component( role = WagonManager.class )
     private WagonManager wagonManager;
+    
+    /**
+     * The current build session instance. This is used for plugin manager API calls.
+     */
+    @Component
+    private MavenSession session;
 
     /**
      * The full URL of the Tomcat manager instance to use.
@@ -216,6 +224,12 @@ public abstract class AbstractCatalinaMojo
 
             manager = new TomcatManager( url, userName, password, charset );
             manager.setUserAgent( name + "/" + version );
+            
+            Proxy proxy = session.getSettings().getActiveProxy();
+            if( proxy != null && proxy.isActive() ) {
+            	getLog().debug("proxy: " + proxy.getHost() + ":" + proxy.getPort());
+            	manager.setProxy(proxy);
+            }
         }
 
         return manager;

--- a/tomcat7-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat7/AbstractCatalinaMojo.java
+++ b/tomcat7-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat7/AbstractCatalinaMojo.java
@@ -20,9 +20,11 @@ package org.apache.tomcat.maven.plugin.tomcat7;
  */
 
 import org.apache.maven.artifact.manager.WagonManager;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.settings.Proxy;
 import org.apache.maven.wagon.authentication.AuthenticationInfo;
 import org.apache.tomcat.maven.common.deployer.TomcatManager;
 import org.apache.tomcat.maven.common.deployer.TomcatManagerException;
@@ -69,6 +71,12 @@ public abstract class AbstractCatalinaMojo
      */
     @Component
     private WagonManager wagonManager;
+    
+    /**
+     * The current build session instance. This is used for plugin manager API calls.
+     */
+    @Component
+    private MavenSession session;
 
     /**
      * The full URL of the Tomcat manager instance to use.
@@ -218,6 +226,12 @@ public abstract class AbstractCatalinaMojo
 
             manager = new TomcatManager( url, userName, password, charset );
             manager.setUserAgent( name + "/" + version );
+
+            Proxy proxy = session.getSettings().getActiveProxy();
+            if( proxy != null && proxy.isActive() ) {
+            	getLog().debug("proxy: " + proxy.getHost() + ":" + proxy.getPort());
+            	manager.setProxy(proxy);
+            }
         }
 
         return manager;


### PR DESCRIPTION
AbstractCatalinaMojo provides TomcatManager with proxy configuration from settings.xml

Note - I've added a MavenSession component to AbstractCatalinaMojo - it would probably be possible to use wagonManager.getProxy(url.getProtocol()) as done here: 

https://code.google.com/p/maven-external-dependency-plugin/issues/detail?id=15 

...I'm not sure if that would be best practice, but it seems to be deprecated: 

http://maven.apache.org/ref/3.0.5/maven-compat/apidocs/org/apache/maven/artifact/manager/WagonManager.html
