### PR TITLE
Support Alternate Session Managers in Standalone War Bootstrap

### DIFF
--- a/tomcat7-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat7/run/AbstractExecWarMojo.java
+++ b/tomcat7-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat7/run/AbstractExecWarMojo.java
@@ -174,6 +174,13 @@ public abstract class AbstractExecWarMojo
     /**
      * see http://tomcat.apache.org/tomcat-7.0-doc/config/valve.html
      */
+    @Parameter( property = "maven.tomcat.exec.war.enableRemoteIpValve", defaultValue = "true",
+                required = true )
+    protected String enableRemoteIpValve;
+
+    /**
+     * see http://tomcat.apache.org/tomcat-7.0-doc/config/valve.html
+     */
     @Parameter( property = "maven.tomcat.exec.war.accessLogValveFormat", defaultValue = "%h %l %u %t %r %s %b %I %D",
                 required = true )
     protected String accessLogValveFormat;
@@ -283,6 +290,7 @@ public abstract class AbstractExecWarMojo
             properties.put( Tomcat7Runner.ARCHIVE_GENERATION_TIMESTAMP_KEY,
                             Long.toString( System.currentTimeMillis() ) );
             properties.put( Tomcat7Runner.ENABLE_NAMING_KEY, Boolean.toString( enableNaming ) );
+            properties.put( Tomcat7Runner.ENABLE_REMOTE_IP_VALVE, enableRemoteIpValve );
             properties.put( Tomcat7Runner.ACCESS_LOG_VALVE_FORMAT_KEY, accessLogValveFormat );
             properties.put( Tomcat7Runner.HTTP_PROTOCOL_KEY, connectorHttpProtocol );
 

--- a/tomcat7-war-runner/src/main/java/org/apache/tomcat/maven/runner/Tomcat7Runner.java
+++ b/tomcat7-war-runner/src/main/java/org/apache/tomcat/maven/runner/Tomcat7Runner.java
@@ -26,6 +26,7 @@ import org.apache.catalina.startup.Catalina;
 import org.apache.catalina.startup.ContextConfig;
 import org.apache.catalina.startup.Tomcat;
 import org.apache.catalina.valves.AccessLogValve;
+import org.apache.catalina.valves.RemoteIpValve;
 import org.apache.juli.ClassLoaderLogManager;
 import org.apache.tomcat.util.ExceptionUtils;
 import org.apache.tomcat.util.http.fileupload.FileUtils;
@@ -68,6 +69,8 @@ public class Tomcat7Runner
 
     public static final String ENABLE_NAMING_KEY = "enableNaming";
 
+    public static final String ENABLE_REMOTE_IP_VALVE = "enableRemoteIpValve";
+    
     public static final String ACCESS_LOG_VALVE_FORMAT_KEY = "accessLogValveFormat";
 
     public static final String CODE_SOURCE_CONTEXT_PATH = "codeSourceContextPath";
@@ -308,6 +311,15 @@ public class Tomcat7Runner
                 tomcat.setConnector( connector );
             }
 
+            boolean enableRemoteIpValve = 
+                Boolean.parseBoolean(runtimeProperties.getProperty( Tomcat7Runner.ENABLE_REMOTE_IP_VALVE, Boolean.TRUE.toString()));
+            
+            if (enableRemoteIpValve) {
+                debugMessage("Adding RemoteIpValve");
+                RemoteIpValve riv = new RemoteIpValve();
+                tomcat.getHost().getPipeline().addValve(riv);
+            }
+            
             // add a default acces log valve
             AccessLogValve alv = new AccessLogValve();
             alv.setDirectory( new File( extractDirectory, "logs" ).getAbsolutePath() );

--- a/tomcat7-war-runner/src/main/java/org/apache/tomcat/maven/runner/Tomcat7Runner.java
+++ b/tomcat7-war-runner/src/main/java/org/apache/tomcat/maven/runner/Tomcat7Runner.java
@@ -18,37 +18,25 @@ package org.apache.tomcat.maven.runner;
  * under the License.
  */
 
-import org.apache.catalina.Context;
-import org.apache.catalina.Host;
-import org.apache.catalina.connector.Connector;
-import org.apache.catalina.core.StandardContext;
-import org.apache.catalina.startup.Catalina;
-import org.apache.catalina.startup.ContextConfig;
-import org.apache.catalina.startup.Tomcat;
-import org.apache.catalina.valves.AccessLogValve;
-import org.apache.catalina.valves.RemoteIpValve;
-import org.apache.juli.ClassLoaderLogManager;
-import org.apache.tomcat.util.ExceptionUtils;
-import org.apache.tomcat.util.http.fileupload.FileUtils;
-
-import java.io.BufferedOutputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
-import java.util.StringTokenizer;
+import java.util.*;
 import java.util.logging.LogManager;
+
+import org.apache.catalina.*;
+import org.apache.catalina.connector.Connector;
+import org.apache.catalina.core.StandardContext;
+import org.apache.catalina.startup.*;
+import org.apache.catalina.valves.AccessLogValve;
+import org.apache.catalina.valves.RemoteIpValve;
+import org.apache.juli.ClassLoaderLogManager;
+import org.apache.tomcat.util.ExceptionUtils;
+import org.apache.tomcat.util.http.fileupload.FileUtils;
 
 /**
  * FIXME add junit for that but when https://issues.apache.org/bugzilla/show_bug.cgi?id=52028 fixed
@@ -109,6 +97,8 @@ public class Tomcat7Runner
     public String extractDirectory = ".extract";
 
     public File extractDirectoryFile;
+    
+    public String sessionManagerFactoryClassName = null;
 
     public String codeSourceContextPath = null;
 
@@ -273,6 +263,11 @@ public class Tomcat7Runner
                     {
                         host.addChild( ctx );
                     }
+                    
+                    if (sessionManagerFactoryClassName != null) {
+                        boolean cookies = true;
+                        constructSessionManager(ctx, sessionManagerFactoryClassName, cookies);
+                    }
 
                     return ctx;
                 }
@@ -320,7 +315,7 @@ public class Tomcat7Runner
                 tomcat.getHost().getPipeline().addValve(riv);
             }
             
-            // add a default acces log valve
+            // add a default access log valve
             AccessLogValve alv = new AccessLogValve();
             alv.setDirectory( new File( extractDirectory, "logs" ).getAbsolutePath() );
             alv.setPattern( runtimeProperties.getProperty( Tomcat7Runner.ACCESS_LOG_VALVE_FORMAT_KEY ) );
@@ -460,6 +455,31 @@ public class Tomcat7Runner
             }
         }
     }
+    
+    private void constructSessionManager(Context ctx, String sessionManagerFactoryClassName, boolean cookies) {
+        try {
+            debugMessage("Constructing session manager with factory " + sessionManagerFactoryClassName);
+            Class sessionManagerClass = Class.forName(sessionManagerFactoryClassName);
+        
+            Object managerFactory = (Object) sessionManagerClass.newInstance();
+            
+            Method method = managerFactory.getClass().getMethod("createSessionManager");
+            if (method != null) {
+                Manager manager = (Manager) method.invoke(managerFactory, null);
+            
+                ctx.setManager(manager);
+                ctx.setCookies(cookies);
+                    
+            } else {
+                System.out.print(sessionManagerFactoryClassName + " does not have a method createSessionManager()");
+            }
+        } catch (Exception e) {
+            System.err.println("Unable to construct specified session manager '" + 
+                    sessionManagerFactoryClassName + "': " + e.getLocalizedMessage());
+            e.printStackTrace();
+        }
+    }
+
 
     private URL getContextXml( String warPath )
         throws IOException

--- a/tomcat7-war-runner/src/main/java/org/apache/tomcat/maven/runner/Tomcat7RunnerCli.java
+++ b/tomcat7-war-runner/src/main/java/org/apache/tomcat/maven/runner/Tomcat7RunnerCli.java
@@ -83,6 +83,10 @@ public class Tomcat7RunnerCli
 
     static Option extractDirectory = OptionBuilder.withArgName( "extractDirectory" ).hasArg().withDescription(
         "path to extract war content, default value: .extract" ).create( "extractDirectory" );
+    
+    static Option sessionManagerFactoryClassName = OptionBuilder.withArgName( "className" ).hasArg().withDescription(
+        "classname of a factory that creates a session manager" ).create( "sessionManagerFactory" );
+
 
     static Option loggerName = OptionBuilder.withArgName( "loggerName" ).hasArg().withDescription(
         "logger to use: slf4j to use slf4j bridge on top of jul" ).create( "loggerName" );
@@ -97,7 +101,7 @@ public class Tomcat7RunnerCli
         options.addOption( httpPort ).addOption( httpsPort ).addOption( ajpPort ).addOption( serverXmlPath ).addOption(
             resetExtract ).addOption( help ).addOption( debug ).addOption( sysProps ).addOption(
             httpProtocol ).addOption( clientAuth ).addOption( keyAlias ).addOption( obfuscate ).addOption(
-            extractDirectory ).addOption( loggerName ).addOption( uriEncoding );
+            extractDirectory ).addOption(sessionManagerFactoryClassName).addOption( loggerName ).addOption( uriEncoding );
     }
 
 
@@ -196,6 +200,11 @@ public class Tomcat7RunnerCli
         if ( line.hasOption( extractDirectory.getOpt() ) )
         {
             tomcat7Runner.extractDirectory = line.getOptionValue( extractDirectory.getOpt() );
+        }
+        
+        if ( line.hasOption( sessionManagerFactoryClassName.getOpt() ) )
+        {
+            tomcat7Runner.sessionManagerFactoryClassName = line.getOptionValue( sessionManagerFactoryClassName.getOpt() );
         }
 
         if ( line.hasOption( loggerName.getOpt() ) )


### PR DESCRIPTION
This PR adds the ability to specify a session manager factory on the command line within the standalone war. This can be used with any session manager that has a factory class with a zero-argument constructor. 

Using this patch, in conjunction with a matching memcached-session-manager patch, you can use the memcached-session-manager with start your standalone project like this:

```
java -Dmsm.memcachedNodes="n1:localhost:21211" -jar standalone.jar \
   -sessionManagerFactory de.javakaffee.web.msm.MemcachedBackupSessionManagerFactory
```

The memcached-session-manager patch can be found here:

https://github.com/magro/memcached-session-manager/pull/33
