### PR TITLE
Adds support for a custom war file name

### DIFF
--- a/tomcat6-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat6/AbstractDeployWarMojo.java
+++ b/tomcat6-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat6/AbstractDeployWarMojo.java
@@ -41,7 +41,8 @@ public class AbstractDeployWarMojo
     /**
      * The path of the WAR file to deploy.
      */
-    @Parameter( defaultValue = "${project.build.directory}/${project.build.finalName}.war", required = true )
+    @Parameter( property = "maven.tomcat.warFile",
+            defaultValue = "${project.build.directory}/${project.build.finalName}.war", required = true )
     private File warFile;
 
     // ----------------------------------------------------------------------

--- a/tomcat7-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat7/deploy/AbstractDeployWarMojo.java
+++ b/tomcat7-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat7/deploy/AbstractDeployWarMojo.java
@@ -41,7 +41,8 @@ public class AbstractDeployWarMojo
     /**
      * The path of the WAR file to deploy.
      */
-    @Parameter( defaultValue = "${project.build.directory}/${project.build.finalName}.war", required = true )
+    @Parameter( property = "maven.tomcat.warFile",
+        defaultValue = "${project.build.directory}/${project.build.finalName}.war", required = true )
     private File warFile;
 
     // ----------------------------------------------------------------------


### PR DESCRIPTION
Currently the war name is always equals to ${project.build.directory}/${project.build.finalName}.war. This is overridable through the pom file in a project, but sometimes this behaviour is undesirable. That's whythis pull request adds support for a custom war name through the command line.

This pull request is divided into two seperate commits, one for tomcat6 and the other for tomcat7.
