### PR TITLE
MTOMCAT-290 - Fix for parallel deployment

### DIFF
--- a/tomcat7-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat7/run/AbstractRunMojo.java
+++ b/tomcat7-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat7/run/AbstractRunMojo.java
@@ -635,7 +635,12 @@ public abstract class AbstractRunMojo
      */
     protected String getPath()
     {
-        return path;
+    	String versionSeparator = "##";
+		if (path.contains(versionSeparator)) {
+			return path.substring(0, path.indexOf(versionSeparator));
+		} else {
+			return path;
+		}
     }
 
     /**

--- a/tomcat7-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat7/run/AbstractRunMojo.java
+++ b/tomcat7-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat7/run/AbstractRunMojo.java
@@ -636,11 +636,11 @@ public abstract class AbstractRunMojo
     protected String getPath()
     {
     	String versionSeparator = "##";
-		if (path.contains(versionSeparator)) {
-			return path.substring(0, path.indexOf(versionSeparator));
-		} else {
-			return path;
-		}
+	if (path.contains(versionSeparator)) {
+		return path.substring(0, path.indexOf(versionSeparator));
+	} else {
+		return path;
+	}
     }
 
     /**


### PR DESCRIPTION
Fix for the probleme explained in MTOMCAT-290 (https://issues.apache.org/jira/browse/MTOMCAT-290).
This fix simply strip the version, if present, from the path when running a WAR.

BEWARE: I did not look into the internals of the project, this patch might have side-effects should not have side effects but I could not verify it (Is there a test suite to run for this plugin?)
