### PR TITLE
Bind Tomcat to an address via command-line option

### DIFF
--- a/tomcat7-war-runner/src/main/java/org/apache/tomcat/maven/runner/Tomcat7Runner.java
+++ b/tomcat7-war-runner/src/main/java/org/apache/tomcat/maven/runner/Tomcat7Runner.java
@@ -87,6 +87,8 @@ public class Tomcat7Runner
     public static final String HTTP_PORT_KEY = "httpPort";
 
 
+    public String httpAddress;
+
     public int httpPort;
 
     public int httpsPort;
@@ -305,15 +307,24 @@ public class Tomcat7Runner
 
             debugMessage( "use connectorHttpProtocol:" + connectorHttpProtocol );
 
-            if ( httpPort > 0 )
+            if ( httpPort > 0  || httpAddress != null)
             {
                 Connector connector = new Connector( connectorHttpProtocol );
-                connector.setPort( httpPort );
                 connector.setMaxPostSize( maxPostSize );
 
-                if ( httpsPort > 0 )
+                if(httpPort > 0)
                 {
-                    connector.setRedirectPort( httpsPort );
+                    connector.setPort( httpPort );
+
+                    if ( httpsPort > 0 )
+                    {
+                        connector.setRedirectPort( httpsPort );
+                    }
+                }
+
+                if( httpAddress != null)
+                {
+                    connector.setProperty("address", httpAddress);
                 }
                 connector.setURIEncoding( uriEncoding );
 

--- a/tomcat7-war-runner/src/main/java/org/apache/tomcat/maven/runner/Tomcat7RunnerCli.java
+++ b/tomcat7-war-runner/src/main/java/org/apache/tomcat/maven/runner/Tomcat7RunnerCli.java
@@ -42,6 +42,9 @@ public class Tomcat7RunnerCli
 
     public static final String STAND_ALONE_PROPERTIES_FILENAME = "tomcat.standalone.properties";
 
+    static Option httpAddress  =
+        OptionBuilder.withArgName( "httpAddress" ).hasArg().withDescription( "http address to use" ).create( "httpAddress" );
+
     static Option httpPort =
         OptionBuilder.withArgName( "httpPort" ).hasArg().withDescription( "http port to use" ).create( "httpPort" );
 
@@ -102,7 +105,8 @@ public class Tomcat7RunnerCli
 
     static
     {
-        options.addOption( httpPort ) //
+        options.addOption( httpAddress ) //
+            .addOption( httpPort ) //
             .addOption( httpsPort ) //
             .addOption( ajpPort ) //
             .addOption( serverXmlPath ) //
@@ -158,6 +162,11 @@ public class Tomcat7RunnerCli
         if ( line.hasOption( serverXmlPath.getOpt() ) )
         {
             tomcat7Runner.serverXmlPath = line.getOptionValue( serverXmlPath.getOpt() );
+        }
+
+        if ( line.hasOption( httpAddress.getOpt() ) )
+        {
+            tomcat7Runner.httpAddress = line.getOptionValue( httpAddress.getOpt() );
         }
 
         String port = tomcat7Runner.runtimeProperties.getProperty( Tomcat7Runner.HTTP_PORT_KEY );


### PR DESCRIPTION
Introduce a -httpAddress command-line option to the Tomcat Runner.
Update the Runner to bind Tomcat to the specified address.

Ex: java -jar webapp.war -httpAddress somehostname
