### PR TITLE
Fixes MTCOMCAT-294: Add URL decoding to fix file lookup for paths containing spaces

### DIFF
--- a/tomcat8-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat8/run/RunMojo.java
+++ b/tomcat8-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat8/run/RunMojo.java
@@ -20,9 +20,7 @@ package org.apache.tomcat.maven.plugin.tomcat8.run;
 
 import org.apache.catalina.Context;
 import org.apache.catalina.WebResource;
-import org.apache.catalina.WebResourceRoot;
 import org.apache.catalina.WebResourceSet;
-import org.apache.catalina.loader.WebappClassLoaderBase;
 import org.apache.catalina.loader.WebappLoader;
 import org.apache.catalina.webresources.EmptyResource;
 import org.apache.catalina.webresources.FileResource;
@@ -475,6 +473,7 @@ public class RunMojo
                             if ( idx >= 0 )
                             {
                                 String filePath = StringUtils.removeStart( url.getFile().substring( 0, idx ), "file:" );
+                                filePath = java.net.URLDecoder.decode(filePath, "UTF-8");
 
                                 jarFile = new JarFile( filePath );
 


### PR DESCRIPTION
Adds necessary URL decoding for file paths containing spaces. This fixes MTOMCAT-294.
