### PR TITLE
Allow port reuse when invoking plugin repeatedly in build

### DIFF
--- a/common-tomcat-maven-plugin/src/main/java/org/apache/tomcat/maven/common/run/EmbeddedRegistry.java
+++ b/common-tomcat-maven-plugin/src/main/java/org/apache/tomcat/maven/common/run/EmbeddedRegistry.java
@@ -108,6 +108,7 @@ public final class EmbeddedRegistry
             {
                 Method method = embedded.getClass().getMethod( "stop", null );
                 method.invoke( embedded, null );
+                embedded.getClass().getMethod( "destroy", null ).invoke( embedded, null );
                 iterator.remove();
             }
             catch ( NoSuchMethodException e )
@@ -115,7 +116,7 @@ public final class EmbeddedRegistry
                 if ( firstException == null )
                 {
                     firstException = e;
-                    error( log, e, "no stop method in class " + embedded.getClass().getName() );
+                    error( log, e, "no stop/destroy method in class " + embedded.getClass().getName() );
                 }
                 else
                 {
@@ -127,7 +128,7 @@ public final class EmbeddedRegistry
                 if ( firstException == null )
                 {
                     firstException = e;
-                    error( log, e, "IllegalAccessException for stop method in class " + embedded.getClass().getName() );
+                    error( log, e, "IllegalAccessException for stop/destroy method in class " + embedded.getClass().getName() );
                 }
                 else
                 {
@@ -140,7 +141,7 @@ public final class EmbeddedRegistry
                 if ( firstException == null )
                 {
                     firstException = e;
-                    error( log, e, "IllegalAccessException for stop method in class " + embedded.getClass().getName() );
+                    error( log, e, "IllegalAccessException for stop/destroy method in class " + embedded.getClass().getName() );
                 }
                 else
                 {


### PR DESCRIPTION
In a multi-module build the tomcat7-maven-plugin can only be invoked once with a given port before encountering errors due to ports being bound. Calling destroy after calling stop on the embedded instances solves this problem.
