### PR TITLE
use provided encoding for https conector

### DIFF
--- a/tomcat7-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat7/run/AbstractRunMojo.java
+++ b/tomcat7-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat7/run/AbstractRunMojo.java
@@ -1202,6 +1202,8 @@ public abstract class AbstractRunMojo
 
                     httpsConnector.setAttribute( "clientAuth", clientAuth );
 
+                    httpsConnector.setURIEncoding( uriEncoding );
+
                     httpsConnector.setUseBodyEncodingForURI( this.useBodyEncodingForURI );
 
                     if ( address != null )


### PR DESCRIPTION
If we specified a custom URI encoding in the pom, it was only set for the http connector and not for the https one.
 this patch fix it.
