### PR TITLE
fix scanning of ServletContainerInitializer by tomcat > 7.0.5x 

### DIFF
--- a/tomcat7-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat7/run/CustomRunContextConfig.java
+++ b/tomcat7-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat7/run/CustomRunContextConfig.java
@@ -1,0 +1,40 @@
+package org.apache.tomcat.maven.plugin.tomcat7.run;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.catalina.startup.ContextConfig;
+
+import javax.servlet.ServletContext;
+import java.util.List;
+
+/**
+ * Created by benoitmeriaux on 29/08/2015.
+ */
+public class CustomRunContextConfig extends ContextConfig {
+
+    /*In order to have the ServletContainerInitializer scanned using the classpath and not using resources path,
+    we need to clear the ORDERED_LIBS attribtues of the ServletContext before the scan*/
+    protected void processServletContainerInitializers(ServletContext servletContext) {
+        List saveOrderedLib = (List) servletContext.getAttribute(ServletContext.ORDERED_LIBS);
+        servletContext.setAttribute(ServletContext.ORDERED_LIBS, null);
+        super.processServletContainerInitializers(servletContext);
+        servletContext.setAttribute(ServletContext.ORDERED_LIBS, saveOrderedLib);
+    }
+
+}

--- a/tomcat7-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat7/run/ExtendedTomcat.java
+++ b/tomcat7-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat7/run/ExtendedTomcat.java
@@ -50,7 +50,7 @@ public class ExtendedTomcat
         ctx.setPath( url );
         ctx.setDocBase( path );
 
-        ContextConfig ctxCfg = new ContextConfig();
+        ContextConfig ctxCfg = new CustomRunContextConfig();
         ctx.addLifecycleListener( ctxCfg );
 
         ctxCfg.setDefaultWebXml( new File( configurationDir, "conf/web.xml" ).getAbsolutePath() );


### PR DESCRIPTION
ServletContainerInitializer not scanned in goal "run"

I found that since tomcat v7.0.5x , because of a refactor on the scanning of the ServletContainerInitializer, it is broken in the tomcat maven plugin in the run goal.

The bug is introduced by the new method of scanning of the new class "org.apache.catalina.startup.WebappServiceLoader" in tomcat core.

The method "load" looks for lib jar path using servletContext.getResource() with the prefix "WEB-INb/lib", but in "run" goal, we do not have the dependencies in this folder, and because the method do not use the classloader, all lib jars are not scanned.

The problematic code path is used if the  "servletContext.getAttribute(ServletContext.ORDERED_LIBS);" return a list.

But if we clear this list, the load method will scan every jar in the classpath.

To fix the problem we have three solutions:
clear the servletContext attribute ServletContext.ORDERED_LIBS, 
or get the lib loaded in dependencies accessible by servletContext.getResource("WEB-INb/lib" + jarName),
or put the dependencies in the parent classloader

The first solution can be easily implemented by extending the ContextConfig class to override the processServletContainerInitializers method in the following way.

  protected void processServletContainerInitializers(ServletContext servletContext) {
        List saveOrderedLib = (List) servletContext.getAttribute(ServletContext.ORDERED_LIBS);
        servletContext.setAttribute(ServletContext.ORDERED_LIBS, null);
        super.processServletContainerInitializers(servletContext);
        servletContext.setAttribute(ServletContext.ORDERED_LIBS, saveOrderedLib);
    }

 and using this custom ContextConfig class in the ExtendedTomcat class.
