### PR TITLE
Ensure that resource paths begin with "/" as required by Tomcat 8.

### DIFF
--- a/tomcat8-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat8/run/RunMojo.java
+++ b/tomcat8-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat8/run/RunMojo.java
@@ -627,7 +627,7 @@ public class RunMojo
 
                             for ( String file : files )
                             {
-                                paths.add( file );
+                                paths.add( path + file );
                             }
 
                             return paths;


### PR DESCRIPTION
This fixes https://issues.apache.org/jira/browse/MTOMCAT-302
