### PR TITLE
fix path resolution under windows

### DIFF
--- a/tomcat8-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat8/run/RunMojo.java
+++ b/tomcat8-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat8/run/RunMojo.java
@@ -475,6 +475,8 @@ public class RunMojo
                             if ( idx >= 0 )
                             {
                                 String filePath = StringUtils.removeStart( url.getFile().substring( 0, idx ), "file:" );
+				// Restore spaces which might be available under windows
+				filePath = filePath.replaceAll("%20", " ");
 
                                 jarFile = new JarFile( filePath );
 

--- a/tomcat8-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat8/run/RunMojo.java
+++ b/tomcat8-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat8/run/RunMojo.java
@@ -470,13 +470,13 @@ public class RunMojo
                             // url.getFile is
                             // file:/Users/olamy/mvn-repo/org/springframework/spring-web/4.0.0.RELEASE/spring-web-4.0.0.RELEASE.jar!/org/springframework/web/context/ContextLoaderListener.class
 
-                            int idx = url.getFile().indexOf( '!' );
+                            URI uri = new URI(url.getFile());
+                            String filePath = uri.getPath();
+                            int idx = filePath.indexOf( '!' );
 
                             if ( idx >= 0 )
                             {
-                                String filePath = StringUtils.removeStart( url.getFile().substring( 0, idx ), "file:" );
-				// Restore spaces which might be available under windows
-				filePath = filePath.replaceAll("%20", " ");
+                                filePath = filePath.substring( 0, idx);
 
                                 jarFile = new JarFile( filePath );
 
@@ -485,16 +485,20 @@ public class RunMojo
                                 return new JarResource( this, //
                                                         getPath(), //
                                                         filePath, //
-                                                        url.getPath().substring( 0, idx ), //
+                                                        "file:"+filePath, //
                                                         jarEntry, //
                                                         "", //
                                                         null );
                             }
                             else
                             {
-                                return new FileResource( this, webAppPath, new File( url.getFile() ), true );
+                                return new FileResource( this, webAppPath, new File( filePath ), true );
                             }
 
+                        }
+                        catch (URISyntaxException e)
+                        {
+                            throw new RuntimeException( e.getMessage(), e );
                         }
                         catch ( IOException e )
                         {


### PR DESCRIPTION
URL translate spaces to %20 and thus is unable to resolve jar paths located in directory with spaces in the path (as is the case under windows).
