### PR TITLE
Allow easy myEclipse development

### DIFF
--- a/common-tomcat-maven-plugin/pom.xml
+++ b/common-tomcat-maven-plugin/pom.xml
@@ -27,7 +27,7 @@
     <version>3.0-SNAPSHOT</version>
   </parent>
   <artifactId>common-tomcat-maven-plugin</artifactId>
-  <name>Apache Tomcat Maven Plugin :: Common API</name>
+  <name>Apache Tomcat Maven Plugin - Common API</name>
 
   <dependencies>
     <dependency>

--- a/tomcat-maven-archetype/pom.xml
+++ b/tomcat-maven-archetype/pom.xml
@@ -33,7 +33,7 @@
 
   <packaging>maven-archetype</packaging>
 
-  <name>Apache Tomcat Maven Plugin :: Archetype</name>
+  <name>Apache Tomcat Maven Plugin - Archetype</name>
 
   <properties>
     <archetypeVersion>2.2</archetypeVersion>

--- a/tomcat-maven-plugin-it/pom.xml
+++ b/tomcat-maven-plugin-it/pom.xml
@@ -28,7 +28,7 @@
 
   <artifactId>tomcat-maven-plugin-it</artifactId>
   <packaging>jar</packaging>
-  <name>Apache Tomcat Maven Plugin :: Integration Tests</name>
+  <name>Apache Tomcat Maven Plugin - Integration Tests</name>
 
   <properties>
     <!-- The time to wait between startup and shutdown of tomcat. Realized by a test which waits for the specified

--- a/tomcat7-maven-plugin/pom.xml
+++ b/tomcat7-maven-plugin/pom.xml
@@ -27,7 +27,7 @@
   </parent>
   <artifactId>tomcat7-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <name>Apache Tomcat Maven Plugin :: Tomcat 7.x</name>
+  <name>Apache Tomcat Maven Plugin - Tomcat 7.x</name>
   <description>The Tomcat Maven Plugin provides goals to manipulate WAR projects within the Tomcat 7.x servlet container.
   </description>
 

--- a/tomcat7-war-runner/pom.xml
+++ b/tomcat7-war-runner/pom.xml
@@ -27,7 +27,7 @@
   </parent>
   <artifactId>tomcat7-war-runner</artifactId>
   <version>3.0-SNAPSHOT</version>
-  <name>Apache Tomcat Maven Plugin :: Tomcat 7.x War Runner</name>
+  <name>Apache Tomcat Maven Plugin - Tomcat 7.x War Runner</name>
 
   <dependencies>
     <dependency>

--- a/tomcat8-maven-plugin/pom.xml
+++ b/tomcat8-maven-plugin/pom.xml
@@ -27,7 +27,7 @@
   </parent>
   <artifactId>tomcat8-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <name>Apache Tomcat Maven Plugin :: Tomcat 8.x</name>
+  <name>Apache Tomcat Maven Plugin - Tomcat 8.x</name>
   <description>The Tomcat Maven Plugin provides goals to manipulate WAR projects within the Tomcat 8.x servlet container.
   </description>
 

--- a/tomcat8-war-runner/pom.xml
+++ b/tomcat8-war-runner/pom.xml
@@ -27,7 +27,7 @@
   </parent>
   <artifactId>tomcat8-war-runner</artifactId>
   <version>3.0-SNAPSHOT</version>
-  <name>Apache Tomcat Maven Plugin :: Tomcat 8.x War Runner</name>
+  <name>Apache Tomcat Maven Plugin - Tomcat 8.x War Runner</name>
 
   <dependencies>
     <dependency>


### PR DESCRIPTION
MyEclipse uses <name> tag when importing projects to workspace by
default.  In order to allow development easily for users of myEclipse,
colons are not allowed in the <name> tag.  This change replaced :: with -.