### PR TITLE
Handle failed tomcat war deployment (status OK but body FAIL)

### DIFF
--- a/common-tomcat-maven-plugin/src/main/resources/org/apache/tomcat/maven/common/messages/messages.properties
+++ b/common-tomcat-maven-plugin/src/main/resources/org/apache/tomcat/maven/common/messages/messages.properties
@@ -109,3 +109,5 @@ ReloadMojo.reloadingApp = Reloading application at {0}
 #
 
 tomcatHttpStatusError = Tomcat return http status error: {0}, Reason Phrase: {1}
+tomcatHttpDeployBodyError = FAIL
+tomcatHttpBodyError = Tomcat return http body error: {0}

--- a/common-tomcat-maven-plugin/src/main/resources/org/apache/tomcat/maven/common/messages/messages_fr.properties
+++ b/common-tomcat-maven-plugin/src/main/resources/org/apache/tomcat/maven/common/messages/messages_fr.properties
@@ -106,4 +106,6 @@ UndeployMojo.undeployError = N'a pas pu retirer l'application : {0}
 
 ReloadMojo.reloadingApp = Rechargement de l'application sur {0}
 
-tomcatHttpStatusError = Tomcat a retourn\u00E9 un code HTTP en erreur: {0}, raison: {1}
+tomcatHttpStatusError = Tomcat a retourn\u00E9 un code HTTP en erreur : {0}, raison : {1}
+tomcatHttpDeployBodyError = ECHEC
+tomcatHttpBodyError = Tomcat a retourn\u00E9 un corps HTTP en erreur : {0}

--- a/common-tomcat-maven-plugin/src/main/resources/org/apache/tomcat/maven/common/messages/messages_fr.properties
+++ b/common-tomcat-maven-plugin/src/main/resources/org/apache/tomcat/maven/common/messages/messages_fr.properties
@@ -106,6 +106,6 @@ UndeployMojo.undeployError = N'a pas pu retirer l'application : {0}
 
 ReloadMojo.reloadingApp = Rechargement de l'application sur {0}
 
-tomcatHttpStatusError = Tomcat a retourn\u00E9 un code HTTP en erreur: {0}, raison: {1}
+tomcatHttpStatusError = Tomcat a retourn\u00E9 un code HTTP en erreur : {0}, raison: {1}
 tomcatHttpDeployBodyError = ECHEC
-tomcatHttpBodyError = Tomcat a retourn\u00E9 un corps HTTP en erreur: {0}
+tomcatHttpBodyError = Tomcat a retourn\u00E9 un corps HTTP en erreur : {0}

--- a/common-tomcat-maven-plugin/src/main/resources/org/apache/tomcat/maven/common/messages/messages_fr.properties
+++ b/common-tomcat-maven-plugin/src/main/resources/org/apache/tomcat/maven/common/messages/messages_fr.properties
@@ -106,6 +106,6 @@ UndeployMojo.undeployError = N'a pas pu retirer l'application : {0}
 
 ReloadMojo.reloadingApp = Rechargement de l'application sur {0}
 
-tomcatHttpStatusError = Tomcat a retourn\u00E9 un code HTTP en erreur : {0}, raison: {1}
+tomcatHttpStatusError = Tomcat a retourn\u00E9 un code HTTP en erreur : {0}, raison : {1}
 tomcatHttpDeployBodyError = ECHEC
 tomcatHttpBodyError = Tomcat a retourn\u00E9 un corps HTTP en erreur : {0}

--- a/common-tomcat-maven-plugin/src/main/resources/org/apache/tomcat/maven/common/messages/messages_fr.properties
+++ b/common-tomcat-maven-plugin/src/main/resources/org/apache/tomcat/maven/common/messages/messages_fr.properties
@@ -107,3 +107,5 @@ UndeployMojo.undeployError = N'a pas pu retirer l'application : {0}
 ReloadMojo.reloadingApp = Rechargement de l'application sur {0}
 
 tomcatHttpStatusError = Tomcat a retourn\u00E9 un code HTTP en erreur: {0}, raison: {1}
+tomcatHttpDeployBodyError = ECHEC
+tomcatHttpBodyError = Tomcat a retourn\u00E9 un corps HTTP en erreur: {0}

--- a/tomcat6-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat6/AbstractI18NTomcat6Mojo.java
+++ b/tomcat6-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat6/AbstractI18NTomcat6Mojo.java
@@ -89,3 +89,4 @@ public abstract class AbstractI18NTomcat6Mojo
             }
     }
 }
+}

--- a/tomcat6-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat6/AbstractI18NTomcat6Mojo.java
+++ b/tomcat6-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat6/AbstractI18NTomcat6Mojo.java
@@ -79,6 +79,14 @@ public abstract class AbstractI18NTomcat6Mojo
                 messagesProvider.getMessage( "tomcatHttpStatusError", statusCode,
                                              tomcatResponse.getReasonPhrase() ) + ": "
                     + tomcatResponse.getHttpResponseBody() );
-        }
+        } else if(tomcatResponse.getHttpResponseBody().startsWith(messagesProvider.getMessage("tomcatHttpDeployBodyError"))) {
+            {
+                getLog().error( messagesProvider.getMessage( "tomcatHttpBodyError",
+                        tomcatResponse.getHttpResponseBody() ) );
+                throw new MojoExecutionException(
+                        messagesProvider.getMessage( "tomcatHttpBodyError",
+                                tomcatResponse.getHttpResponseBody() ));
+            }
     }
+}
 }

--- a/tomcat6-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat6/AbstractI18NTomcat6Mojo.java
+++ b/tomcat6-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat6/AbstractI18NTomcat6Mojo.java
@@ -79,6 +79,13 @@ public abstract class AbstractI18NTomcat6Mojo
                 messagesProvider.getMessage( "tomcatHttpStatusError", statusCode,
                                              tomcatResponse.getReasonPhrase() ) + ": "
                     + tomcatResponse.getHttpResponseBody() );
-        }
+        } else if(tomcatResponse.getHttpResponseBody().startsWith(messagesProvider.getMessage("tomcatHttpDeployBodyError"))) {
+            {
+                getLog().error( messagesProvider.getMessage( "tomcatHttpBodyError",
+                        tomcatResponse.getHttpResponseBody() ) );
+                throw new MojoExecutionException(
+                        messagesProvider.getMessage( "tomcatHttpBodyError",
+                                tomcatResponse.getHttpResponseBody() ));
+            }
     }
 }

--- a/tomcat7-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat7/AbstractTomcat7Mojo.java
+++ b/tomcat7-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat7/AbstractTomcat7Mojo.java
@@ -77,6 +77,14 @@ public abstract class AbstractTomcat7Mojo
                 messagesProvider.getMessage( "tomcatHttpStatusError", statusCode,
                                              tomcatResponse.getReasonPhrase() ) + ": "
                     + tomcatResponse.getHttpResponseBody() );
+        } else if(tomcatResponse.getHttpResponseBody().startsWith(messagesProvider.getMessage("tomcatHttpDeployBodyError"))) {
+            {
+                getLog().error( messagesProvider.getMessage( "tomcatHttpBodyError",
+                        tomcatResponse.getHttpResponseBody() ) );
+                throw new MojoExecutionException(
+                        messagesProvider.getMessage( "tomcatHttpBodyError",
+                                tomcatResponse.getHttpResponseBody() ));
+            }
         }
     }
 }

--- a/tomcat8-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat8/AbstractTomcat8Mojo.java
+++ b/tomcat8-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat8/AbstractTomcat8Mojo.java
@@ -77,6 +77,13 @@ public abstract class AbstractTomcat8Mojo
                 messagesProvider.getMessage( "tomcatHttpStatusError", statusCode,
                                              tomcatResponse.getReasonPhrase() ) + ": "
                     + tomcatResponse.getHttpResponseBody() );
-        }
+        } else if(tomcatResponse.getHttpResponseBody().startsWith(messagesProvider.getMessage("tomcatHttpDeployBodyError"))) {
+            {
+                getLog().error( messagesProvider.getMessage( "tomcatHttpBodyError",
+                        tomcatResponse.getHttpResponseBody() ) );
+                throw new MojoExecutionException(
+                        messagesProvider.getMessage( "tomcatHttpBodyError",
+                                tomcatResponse.getHttpResponseBody() ));
+            }
     }
 }

--- a/tomcat8-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat8/AbstractTomcat8Mojo.java
+++ b/tomcat8-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat8/AbstractTomcat8Mojo.java
@@ -87,3 +87,4 @@ public abstract class AbstractTomcat8Mojo
             }
     }
 }
+}

--- a/tomcat8-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat8/AbstractTomcat8Mojo.java
+++ b/tomcat8-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat8/AbstractTomcat8Mojo.java
@@ -77,6 +77,14 @@ public abstract class AbstractTomcat8Mojo
                 messagesProvider.getMessage( "tomcatHttpStatusError", statusCode,
                                              tomcatResponse.getReasonPhrase() ) + ": "
                     + tomcatResponse.getHttpResponseBody() );
-        }
+        } else if(tomcatResponse.getHttpResponseBody().startsWith(messagesProvider.getMessage("tomcatHttpDeployBodyError"))) {
+            {
+                getLog().error( messagesProvider.getMessage( "tomcatHttpBodyError",
+                        tomcatResponse.getHttpResponseBody() ) );
+                throw new MojoExecutionException(
+                        messagesProvider.getMessage( "tomcatHttpBodyError",
+                                tomcatResponse.getHttpResponseBody() ));
+            }
     }
+}
 }


### PR DESCRIPTION
per http://tomcat.apache.org/tomcat-7.0-doc/manager-howto.html a failed deploy will trigger a body with status code 200 but with body response starting with FAIL (i18n)

this patch adds the FAIL body response handler for en/fr languages

unsure if tests are really needed (?)