### PR TITLE
PFCORE-7274 upgrade tomcat 7 version to 7.0.92

### DIFF
--- a/common-tomcat-maven-plugin/pom.xml
+++ b/common-tomcat-maven-plugin/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>tomcat-maven-plugin</artifactId>
     <groupId>org.apache.tomcat.maven</groupId>
-    <version>3.0</version>
+    <version>3.1-SNAPSHOT</version>
   </parent>
   <artifactId>common-tomcat-maven-plugin</artifactId>
   <name>Apache Tomcat Maven Plugin :: Common API</name>

--- a/common-tomcat-maven-plugin/pom.xml
+++ b/common-tomcat-maven-plugin/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>tomcat-maven-plugin</artifactId>
     <groupId>org.apache.tomcat.maven</groupId>
-    <version>3.0-SNAPSHOT</version>
+    <version>3.0</version>
   </parent>
   <artifactId>common-tomcat-maven-plugin</artifactId>
   <name>Apache Tomcat Maven Plugin :: Common API</name>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
   <artifactId>tomcat-maven-plugin</artifactId>
   <packaging>pom</packaging>
   <name>Apache Tomcat Maven Plugin</name>
-  <version>3.0-SNAPSHOT</version>
+  <version>3.0</version>
   <description>The Tomcat Maven Plugin provides goals to manipulate WAR projects within the Tomcat servlet
     container.
   </description>

--- a/pom.xml
+++ b/pom.xml
@@ -847,21 +847,18 @@
   </build>
 
   <distributionManagement>
-    <repository>
-      <id>apache.releases.https</id>
-      <name>Apache Release Distribution Repository</name>
-      <url>${distributionReleaseUrl}</url>
-    </repository>
-
-    <snapshotRepository>
-      <id>${distributionIdSnapshots}</id>
-      <name>Apache Development Snapshot Repository</name>
-      <url>${distributionSnapshotsUrl}</url>
-    </snapshotRepository>
-    <site>
-      <id>apache.website</id>
-      <url>${tomcat-maven.siteUrlDeployment}</url>
-    </site>
+	<repository>
+		<id>ifactory-releases</id>
+		<url>
+			http://nexus.pubfactory.com/nexus/content/repositories/releases
+		</url>
+	</repository>
+	<snapshotRepository>
+		<id>ifactory-snapshots</id>
+		<url>
+			http://nexus.pubfactory.com/nexus/content/repositories/snapshots
+		</url>
+	</snapshotRepository>
   </distributionManagement>
 
   <reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
   <artifactId>tomcat-maven-plugin</artifactId>
   <packaging>pom</packaging>
   <name>Apache Tomcat Maven Plugin</name>
-  <version>3.0</version>
+  <version>3.1-SNAPSHOT</version>
   <description>The Tomcat Maven Plugin provides goals to manipulate WAR projects within the Tomcat servlet
     container.
   </description>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <its.ajp.port>2001</its.ajp.port>
     <!-- server port for it tests -->
     <its.server.port>2008</its.server.port>
-    <tomcat7Version>7.0.59</tomcat7Version>
+    <tomcat7Version>7.0.92</tomcat7Version>
     <tomcat8Version>8.0.14</tomcat8Version>
 
     <!-- to prevent isssues with last apache parent pom -->

--- a/tomcat-maven-archetype/pom.xml
+++ b/tomcat-maven-archetype/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.tomcat.maven</groupId>
     <artifactId>tomcat-maven-plugin</artifactId>
-    <version>3.0-SNAPSHOT</version>
+    <version>3.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tomcat-maven-archetype/pom.xml
+++ b/tomcat-maven-archetype/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.tomcat.maven</groupId>
     <artifactId>tomcat-maven-plugin</artifactId>
-    <version>3.0</version>
+    <version>3.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tomcat-maven-plugin-it/pom.xml
+++ b/tomcat-maven-plugin-it/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.tomcat.maven</groupId>
     <artifactId>tomcat-maven-plugin</artifactId>
-    <version>3.0-SNAPSHOT</version>
+    <version>3.0</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/tomcat-maven-plugin-it/pom.xml
+++ b/tomcat-maven-plugin-it/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.tomcat.maven</groupId>
     <artifactId>tomcat-maven-plugin</artifactId>
-    <version>3.0</version>
+    <version>3.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/tomcat6-maven-plugin/pom.xml
+++ b/tomcat6-maven-plugin/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.tomcat.maven</groupId>
     <artifactId>tomcat-maven-plugin</artifactId>
-    <version>3.0-SNAPSHOT</version>
+    <version>3.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tomcat6-maven-plugin/pom.xml
+++ b/tomcat6-maven-plugin/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.apache.tomcat.maven</groupId>
     <artifactId>tomcat-maven-plugin</artifactId>
-    <version>3.0</version>
+    <version>3.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/tomcat7-maven-plugin/pom.xml
+++ b/tomcat7-maven-plugin/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>tomcat-maven-plugin</artifactId>
     <groupId>org.apache.tomcat.maven</groupId>
-    <version>3.0</version>
+    <version>3.1-SNAPSHOT</version>
   </parent>
   <artifactId>tomcat7-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>

--- a/tomcat7-maven-plugin/pom.xml
+++ b/tomcat7-maven-plugin/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>tomcat-maven-plugin</artifactId>
     <groupId>org.apache.tomcat.maven</groupId>
-    <version>3.0-SNAPSHOT</version>
+    <version>3.0</version>
   </parent>
   <artifactId>tomcat7-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>

--- a/tomcat7-war-runner/pom.xml
+++ b/tomcat7-war-runner/pom.xml
@@ -23,10 +23,10 @@
   <parent>
     <artifactId>tomcat-maven-plugin</artifactId>
     <groupId>org.apache.tomcat.maven</groupId>
-    <version>3.0</version>
+    <version>3.1-SNAPSHOT</version>
   </parent>
   <artifactId>tomcat7-war-runner</artifactId>
-  <version>3.0</version>
+  <version>3.1-SNAPSHOT</version>
   <name>Apache Tomcat Maven Plugin :: Tomcat 7.x War Runner</name>
 
   <dependencies>

--- a/tomcat7-war-runner/pom.xml
+++ b/tomcat7-war-runner/pom.xml
@@ -23,10 +23,10 @@
   <parent>
     <artifactId>tomcat-maven-plugin</artifactId>
     <groupId>org.apache.tomcat.maven</groupId>
-    <version>3.0-SNAPSHOT</version>
+    <version>3.0</version>
   </parent>
   <artifactId>tomcat7-war-runner</artifactId>
-  <version>3.0-SNAPSHOT</version>
+  <version>3.0</version>
   <name>Apache Tomcat Maven Plugin :: Tomcat 7.x War Runner</name>
 
   <dependencies>

--- a/tomcat8-maven-plugin/pom.xml
+++ b/tomcat8-maven-plugin/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>tomcat-maven-plugin</artifactId>
     <groupId>org.apache.tomcat.maven</groupId>
-    <version>3.0</version>
+    <version>3.1-SNAPSHOT</version>
   </parent>
   <artifactId>tomcat8-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>

--- a/tomcat8-maven-plugin/pom.xml
+++ b/tomcat8-maven-plugin/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <artifactId>tomcat-maven-plugin</artifactId>
     <groupId>org.apache.tomcat.maven</groupId>
-    <version>3.0-SNAPSHOT</version>
+    <version>3.0</version>
   </parent>
   <artifactId>tomcat8-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>

--- a/tomcat8-war-runner/pom.xml
+++ b/tomcat8-war-runner/pom.xml
@@ -23,10 +23,10 @@
   <parent>
     <artifactId>tomcat-maven-plugin</artifactId>
     <groupId>org.apache.tomcat.maven</groupId>
-    <version>3.0-SNAPSHOT</version>
+    <version>3.0</version>
   </parent>
   <artifactId>tomcat8-war-runner</artifactId>
-  <version>3.0-SNAPSHOT</version>
+  <version>3.0</version>
   <name>Apache Tomcat Maven Plugin :: Tomcat 8.x War Runner</name>
 
   <dependencies>

--- a/tomcat8-war-runner/pom.xml
+++ b/tomcat8-war-runner/pom.xml
@@ -23,10 +23,10 @@
   <parent>
     <artifactId>tomcat-maven-plugin</artifactId>
     <groupId>org.apache.tomcat.maven</groupId>
-    <version>3.0</version>
+    <version>3.1-SNAPSHOT</version>
   </parent>
   <artifactId>tomcat8-war-runner</artifactId>
-  <version>3.0</version>
+  <version>3.1-SNAPSHOT</version>
   <name>Apache Tomcat Maven Plugin :: Tomcat 8.x War Runner</name>
 
   <dependencies>


### PR DESCRIPTION
My team is trying to get our Java 8 compiled source application in a place where it can run on tomcat 7.x and Java 11.  Doing this means including a bunch of modularized jars.  When we added them on these older versions of tomcat 7.x we had issues and needed to upgrade all our tomcat servers.  We also needed to upgrade this plugin