### PR TITLE
Make Tomcat 7 >= 7.0.100 work again with AJP

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <its.ajp.port>2001</its.ajp.port>
     <!-- server port for it tests -->
     <its.server.port>2008</its.server.port>
-    <tomcat7Version>7.0.59</tomcat7Version>
+    <tomcat7Version>7.0.103</tomcat7Version>
     <tomcat8Version>8.0.14</tomcat8Version>
 
     <!-- to prevent isssues with last apache parent pom -->

--- a/tomcat7-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat7/run/AbstractRunMojo.java
+++ b/tomcat7-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat7/run/AbstractRunMojo.java
@@ -33,6 +33,7 @@ import org.apache.catalina.startup.Tomcat;
 import org.apache.catalina.valves.AccessLogValve;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.coyote.ajp.AbstractAjpProtocol;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.factory.ArtifactFactory;
 import org.apache.maven.artifact.repository.ArtifactRepository;
@@ -1232,6 +1233,7 @@ public abstract class AbstractRunMojo
                     {
                         ajpConnector.setAttribute( "address", address );
                     }
+                    ((AbstractAjpProtocol<?>) ajpConnector.getProtocolHandler()).setSecretRequired(false);
                     embeddedTomcat.getEngine().getService().addConnector( ajpConnector );
                 }
 


### PR DESCRIPTION
Since https://github.com/apache/tomcat/commit/40d5d93bd284033cf4a1f77f5492444f83d803e2 AJP does not work with the tomcat7-maven-plugin any more and the tomcat7-maven-plugin does not offer properties for configuring the mandatory secret. For development purposes we do not need this security feature, so this PR disables it by setting secretRequired to false.

This patch uses Tomcat 7.0.103 which is not released yet, since previous versions are buggy. 7.0.103 release candidate can be obtained here: https://www.mail-archive.com/dev@tomcat.apache.org/msg141473.html