### PR TITLE
Fix typos and minor grammar issues in README

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,18 +1,18 @@
 Build Apache Tomcat Maven Plugin
 --------------------------------
-To build this project you must Apache Maven at least 2.2.1 .
+To build this project you must have Apache Maven at least 2.2.1.
 mvn clean install will install the mojos without running integration tests.
 As there are some hardcoded integration tests with http port 1973, ajp 2001 and 2008, you could have some port allocation issues (if you don't know why those values ask olamy :-) )
 mvn clean install -Prun-its will run integration tests too: to override the default used http port you can use -Dits.http.port= -Dits.ajp.port=
 
 Snapshots deployment
 ---------------------
-To deploy a snaphot version to https://repository.apache.org/content/repositories/snapshots/, you must run : mvn clean deploy .
+To deploy a snapshot version to https://repository.apache.org/content/repositories/snapshots/, you must run : mvn clean deploy .
 Note you need some configuration in ~/.m2/settings.xml:
     <server>
       <id>apache.snapshots.https</id>
       <username>your asf id</username>
-      <password>your asf paswword</password>
+      <password>your asf password</password>
     </server
 
 NOTE: a Jenkins job deploys SNAPSHOT automatically https://builds.apache.org/job/TomcatMavenPlugin-mvn3.x/.
@@ -21,7 +21,7 @@ So no real need to deploy manually, just commit and Jenkins will do the job for 
 Site deployment
 -----------------
 
-Checkstyle: this project uses the Apache Maven checkstyle configuration for ide codestyle files see http://maven.apache.org/developers/committer-environment.html .
+Checkstyle: this project uses the Apache Maven checkstyle configuration for ide code style files see http://maven.apache.org/developers/committer-environment.html .
 
 Site: to test site generation, just run: mvn site. If you want more reporting (javadoc, pmd, checkstyle, jxr, changelog from jira entries), use: mvn site -Preporting.
 
@@ -31,7 +31,7 @@ When releasing deploy with -Psite-release
 
 Releasing
 ----------
-For release your ~/.m2/settings.xml must contains :
+For release your ~/.m2/settings.xml must contain:
 
     <server>
       <id>apache.releases.https</id>


### PR DESCRIPTION
This PR corrects a few typos and improves grammar and readability in README.txt.

Changes include:
- Fix spelling mistakes
- Improve sentence structure for clarity

The file remains as `.txt` to preserve legacy formatting. Converting to Markdown could be considered in the future.
