### PR TITLE
Fix RAT failures for archetype test resources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -786,6 +786,8 @@
               <exclude>.extract/**</exclude>
               <exclude>*.patch</exclude>
               <exclude>**/access_log.*</exclude>
+              <exclude>**/goal.txt</exclude>
+              <exclude>**/archetype.properties</exclude>
             </excludes>
           </configuration>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -786,8 +786,8 @@
               <exclude>.extract/**</exclude>
               <exclude>*.patch</exclude>
               <exclude>**/access_log.*</exclude>
-              <exclude>**/goal.txt</exclude>
-              <exclude>**/archetype.properties</exclude>
+              <exclude>**/src/test/resources/**/goal.txt</exclude>
+              <exclude>**/src/test/resources/**/archetype.properties</exclude>
             </excludes>
           </configuration>
         </plugin>


### PR DESCRIPTION
This PR resolves RAT license check failures by excluding `archetype.properties` and `goal.txt` in the parent POM. Although these files are already excluded in the archetype module’s POM, the parent-level RAT execution was scanning them during the global build, causing false positives. These files are internal to the archetype and build process, not part of distributed artifacts, and do not require license headers. The change prevents unnecessary RAT failures while ensuring all other source and test files are fully checked.