### PR TITLE
Update deprecated plugin configurations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -593,9 +593,6 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-install-plugin</artifactId>
           <version>3.1.4</version>
-          <configuration>
-            <createChecksum>true</createChecksum>
-          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -658,20 +655,20 @@
           <artifactId>apache-rat-plugin</artifactId>
           <version>0.17</version>
           <configuration>
-            <excludes>
-              <exclude>.gitignore</exclude>
-              <exclude>DEPENDENCIES</exclude>
-              <exclude>README.txt</exclude>
-              <exclude>*.sh</exclude>
-              <exclude>.git/**</exclude>
-              <exclude>.idea/**</exclude>
-              <exclude>out/**</exclude>
-              <exclude>.extract/**</exclude>
-              <exclude>*.patch</exclude>
-              <exclude>**/access_log.*</exclude>
-              <exclude>**/src/test/resources/**/goal.txt</exclude>
-              <exclude>**/src/test/resources/**/archetype.properties</exclude>
-            </excludes>
+            <inputExcludes>
+              <inputExclude>.gitignore</inputExclude>
+              <inputExclude>DEPENDENCIES</inputExclude>
+              <inputExclude>README.txt</inputExclude>
+              <inputExclude>*.sh</inputExclude>
+              <inputExclude>.git/**</inputExclude>
+              <inputExclude>.idea/**</inputExclude>
+              <inputExclude>out/**</inputExclude>
+              <inputExclude>.extract/**</inputExclude>
+              <inputExclude>*.patch</inputExclude>
+              <inputExclude>**/access_log.*</inputExclude>
+              <inputExclude>**/src/test/resources/**/goal.txt</inputExclude>
+              <inputExclude>**/src/test/resources/**/archetype.properties</inputExclude>
+            </inputExcludes>
           </configuration>
         </plugin>
 

--- a/tomcat-maven-archetype/pom.xml
+++ b/tomcat-maven-archetype/pom.xml
@@ -74,16 +74,16 @@
           <groupId>org.apache.rat</groupId>
           <artifactId>apache-rat-plugin</artifactId>
           <configuration>
-            <excludes>
-              <exclude>.gitignore</exclude>
-              <exclude>DEPENDENCIES</exclude>
-              <exclude>README.txt</exclude>
-              <exclude>*.sh</exclude>
-              <exclude>.git/**</exclude>
-              <exclude>.extract/**</exclude>
-              <exclude>src/main/resources/archetype-resources/*/src/main/webapp/js/jquery-1.7.js</exclude>
-              <exclude>src/test/**</exclude>
-            </excludes>
+            <inputExcludes>
+              <inputExclude>.gitignore</inputExclude>
+              <inputExclude>DEPENDENCIES</inputExclude>
+              <inputExclude>README.txt</inputExclude>
+              <inputExclude>*.sh</inputExclude>
+              <inputExclude>.git/**</inputExclude>
+              <inputExclude>.extract/**</inputExclude>
+              <inputExclude>src/main/resources/archetype-resources/*/src/main/webapp/js/jquery-1.7.js</inputExclude>
+              <inputExclude>src/test/**</inputExclude>
+            </inputExcludes>S
           </configuration>
         </plugin>
       </plugins>


### PR DESCRIPTION
- Replace `<exclude>` with `<inputExclude>` for RAT plugin (0.17+)
- Remove unsupported `<createChecksum>` from maven-install-plugin (3.x+)

Eliminates unnecessary build warnings with no functional changes.