### PR TITLE
Modernize Maven API usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -589,6 +589,12 @@
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
+            <artifactId>maven-resolver-provider</artifactId>
+            <scope>provided</scope>
+            <version>${mavenVersion}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
             <artifactId>maven-archiver</artifactId>
             <version>3.6.6</version>
         </dependency>

--- a/src/main/java/org/apache/tomcat/maven/common/run/ClassLoaderEntriesCalculatorRequest.java
+++ b/src/main/java/org/apache/tomcat/maven/common/run/ClassLoaderEntriesCalculatorRequest.java
@@ -19,7 +19,6 @@
 package org.apache.tomcat.maven.common.run;
 
 import org.apache.maven.artifact.Artifact;
-import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 
@@ -32,8 +31,6 @@ import java.util.Set;
 public class ClassLoaderEntriesCalculatorRequest
 {
     private MavenProject mavenProject;
-
-    private MavenSession mavenSession;
 
     private Set<Artifact> dependencies;
 
@@ -51,17 +48,6 @@ public class ClassLoaderEntriesCalculatorRequest
     public ClassLoaderEntriesCalculatorRequest setMavenProject( MavenProject mavenProject )
     {
         this.mavenProject = mavenProject;
-        return this;
-    }
-
-    public MavenSession getMavenSession()
-    {
-        return mavenSession;
-    }
-
-    public ClassLoaderEntriesCalculatorRequest setMavenSession( MavenSession mavenSession )
-    {
-        this.mavenSession = mavenSession;
         return this;
     }
 

--- a/src/main/java/org/apache/tomcat/maven/common/run/ClassLoaderEntriesCalculatorRequest.java
+++ b/src/main/java/org/apache/tomcat/maven/common/run/ClassLoaderEntriesCalculatorRequest.java
@@ -19,6 +19,7 @@
 package org.apache.tomcat.maven.common.run;
 
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 
@@ -31,6 +32,8 @@ import java.util.Set;
 public class ClassLoaderEntriesCalculatorRequest
 {
     private MavenProject mavenProject;
+
+    private MavenSession mavenSession;
 
     private Set<Artifact> dependencies;
 
@@ -48,6 +51,17 @@ public class ClassLoaderEntriesCalculatorRequest
     public ClassLoaderEntriesCalculatorRequest setMavenProject( MavenProject mavenProject )
     {
         this.mavenProject = mavenProject;
+        return this;
+    }
+
+    public MavenSession getMavenSession()
+    {
+        return mavenSession;
+    }
+
+    public ClassLoaderEntriesCalculatorRequest setMavenSession( MavenSession mavenSession )
+    {
+        this.mavenSession = mavenSession;
         return this;
     }
 

--- a/src/main/java/org/apache/tomcat/maven/common/run/DefaultClassLoaderEntriesCalculator.java
+++ b/src/main/java/org/apache/tomcat/maven/common/run/DefaultClassLoaderEntriesCalculator.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -29,7 +30,6 @@ import java.util.Set;
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
-import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.archiver.ArchiverException;
@@ -50,9 +50,6 @@ public class DefaultClassLoaderEntriesCalculator
 
     @Requirement
     private ArchiverManager archiverManager;
-
-    @Requirement
-    private MavenSession mavenSession;
 
 
     @Override
@@ -242,11 +239,12 @@ public class DefaultClassLoaderEntriesCalculator
 
     protected boolean isInProjectReferences( Artifact artifact, MavenProject project )
     {
-        if ( mavenSession == null || mavenSession.getProjects() == null || mavenSession.getProjects().isEmpty() )
+        if ( project.getProjectReferences() == null || project.getProjectReferences().isEmpty() )
         {
             return false;
         }
-        for ( MavenProject mavenProject : mavenSession.getProjects() )
+        Collection<MavenProject> mavenProjects = project.getProjectReferences().values();
+        for ( MavenProject mavenProject : mavenProjects )
         {
             if ( mavenProject.getId() != null && mavenProject.getId().equals( artifact.getId() ) )
             {

--- a/src/main/java/org/apache/tomcat/maven/common/run/DefaultClassLoaderEntriesCalculator.java
+++ b/src/main/java/org/apache/tomcat/maven/common/run/DefaultClassLoaderEntriesCalculator.java
@@ -18,9 +18,18 @@
  */
 package org.apache.tomcat.maven.common.run;
 
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.archiver.ArchiverException;
@@ -29,16 +38,6 @@ import org.codehaus.plexus.archiver.manager.ArchiverManager;
 import org.codehaus.plexus.archiver.manager.NoSuchArchiverException;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
-
-
-import java.io.File;
-import java.io.FilenameFilter;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
 
 /**
  * @author Olivier Lamy
@@ -51,6 +50,9 @@ public class DefaultClassLoaderEntriesCalculator
 
     @Requirement
     private ArchiverManager archiverManager;
+
+    @Requirement
+    private MavenSession mavenSession;
 
 
     @Override
@@ -240,12 +242,11 @@ public class DefaultClassLoaderEntriesCalculator
 
     protected boolean isInProjectReferences( Artifact artifact, MavenProject project )
     {
-        if ( project.getProjectReferences() == null || project.getProjectReferences().isEmpty() )
+        if ( mavenSession == null || mavenSession.getProjects() == null || mavenSession.getProjects().isEmpty() )
         {
             return false;
         }
-        Collection<MavenProject> mavenProjects = project.getProjectReferences().values();
-        for ( MavenProject mavenProject : mavenProjects )
+        for ( MavenProject mavenProject : mavenSession.getProjects() )
         {
             if ( mavenProject.getId() != null && mavenProject.getId().equals( artifact.getId() ) )
             {

--- a/src/main/java/org/apache/tomcat/maven/plugin/tomcat/AbstractCatalinaMojo.java
+++ b/src/main/java/org/apache/tomcat/maven/plugin/tomcat/AbstractCatalinaMojo.java
@@ -18,20 +18,23 @@
  */
 package org.apache.tomcat.maven.plugin.tomcat;
 
-import org.apache.maven.artifact.manager.WagonManager;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugins.annotations.Component;
-import org.apache.maven.plugins.annotations.Parameter;
-import org.apache.maven.wagon.authentication.AuthenticationInfo;
-import org.apache.tomcat.maven.common.deployer.TomcatManager;
-import org.apache.tomcat.maven.common.deployer.TomcatManagerException;
-
-
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Map;
 import java.util.StringTokenizer;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.settings.Server;
+import org.apache.maven.settings.crypto.DefaultSettingsDecryptionRequest;
+import org.apache.maven.settings.crypto.SettingsDecrypter;
+import org.apache.maven.settings.crypto.SettingsDecryptionRequest;
+import org.apache.maven.settings.crypto.SettingsDecryptionResult;
+import org.apache.tomcat.maven.common.deployer.TomcatManager;
+import org.apache.tomcat.maven.common.deployer.TomcatManagerException;
 
 /**
  * Abstract goal that provides common configuration for Catalina-based goals.
@@ -63,12 +66,6 @@ public abstract class AbstractCatalinaMojo
     // ----------------------------------------------------------------------
     // Mojo Parameters
     // ----------------------------------------------------------------------
-
-    /**
-     * The Maven Wagon manager to use when obtaining server authentication details.
-     */
-    @Component
-    private WagonManager wagonManager;
 
     /**
      * The full URL of the Tomcat manager instance to use.
@@ -107,6 +104,16 @@ public abstract class AbstractCatalinaMojo
 
     @Parameter( defaultValue = "${plugin.version}", required = true, readonly = true )
     private String version;
+
+    // ----------------------------------------------------------------------
+    // Mojo Components
+    // ----------------------------------------------------------------------
+
+    /**
+     * Component used to decrypt server passwords from Maven settings.
+     */
+    @Component
+    protected SettingsDecrypter settingsDecrypter;
 
     // ----------------------------------------------------------------------
     // Fields
@@ -173,7 +180,7 @@ public abstract class AbstractCatalinaMojo
         // lazily instantiate when config values have been injected
         if ( manager == null )
         {
-            String userName;
+            String userName = null;
             String password;
 
             if ( server == null )
@@ -185,24 +192,51 @@ public abstract class AbstractCatalinaMojo
             }
             else
             {
-                // obtain authenication details for specified server from wagon
-                AuthenticationInfo info = wagonManager.getAuthenticationInfo( server );
-                if ( info == null )
+                // obtain authentication details for specified server from settings
+                Server settingsServer = settings.getServer( server );
+                if ( settingsServer == null )
                 {
                     throw new MojoExecutionException(
                         messagesProvider.getMessage( "AbstractCatalinaMojo.unknownServer", server ) );
                 }
 
-                // derive username
-                userName = info.getUserName();
-                if ( userName == null )
+                // decrypt the server password
+                String decryptedPassword = null;
+                Object configObj = settingsServer.getConfiguration();
+                if ( configObj instanceof Map )
+                {
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> config = (Map<String, Object>) configObj;
+                    if ( config.get( "password" ) != null )
+                    {
+                        SettingsDecryptionRequest decryptionRequest =
+                            new DefaultSettingsDecryptionRequest( settingsServer );
+                        SettingsDecryptionResult decryptionResult = settingsDecrypter.decrypt( decryptionRequest );
+                        Object decryptedConfigObj = decryptionResult.getServer().getConfiguration();
+                        if ( decryptedConfigObj instanceof Map )
+                        {
+                            @SuppressWarnings("unchecked")
+                            Map<String, Object> decryptedConfig = (Map<String, Object>) decryptedConfigObj;
+                            if ( decryptedConfig.get( "password" ) != null )
+                            {
+                                decryptedPassword = (String) decryptedConfig.get( "password" );
+                            }
+                        }
+                    }
+
+                    // derive username
+                    if ( config.get( "username" ) != null )
+                    {
+                        userName = (String) config.get( "username" );
+                    }
+                }
+                if ( userName == null || userName.isEmpty() )
                 {
                     getLog().debug( messagesProvider.getMessage( "AbstractCatalinaMojo.defaultUserName" ) );
                     userName = DEFAULT_USERNAME;
                 }
 
-                // derive password
-                password = info.getPassword();
+                password = decryptedPassword;
                 if ( password == null )
                 {
                     getLog().debug( messagesProvider.getMessage( "AbstractCatalinaMojo.defaultPassword" ) );

--- a/src/main/java/org/apache/tomcat/maven/plugin/tomcat/run/AbstractExecWarMojo.java
+++ b/src/main/java/org/apache/tomcat/maven/plugin/tomcat/run/AbstractExecWarMojo.java
@@ -38,13 +38,11 @@ import org.apache.commons.compress.archivers.ArchiveStreamFactory;
 import org.apache.commons.compress.archivers.jar.JarArchiveEntry;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-
 import org.apache.maven.artifact.Artifact;
-import org.apache.maven.artifact.factory.ArtifactFactory;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
 import org.apache.maven.artifact.repository.ArtifactRepository;
-import org.apache.maven.artifact.resolver.ArtifactNotFoundException;
-import org.apache.maven.artifact.resolver.ArtifactResolutionException;
-import org.apache.maven.artifact.resolver.ArtifactResolver;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -59,6 +57,10 @@ import org.codehaus.plexus.archiver.jar.Manifest;
 import org.codehaus.plexus.archiver.jar.ManifestException;
 import org.codehaus.plexus.util.DirectoryScanner;
 import org.codehaus.plexus.util.SelectorUtils;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.eclipse.aether.resolution.ArtifactResult;
 
 /**
  * @author Olivier Lamy
@@ -120,14 +122,13 @@ public abstract class AbstractExecWarMojo
     @Parameter
     protected List<WarRunDependency> warRunDependencies;
 
-    @Component
-    protected ArtifactResolver artifactResolver;
-
     /**
-     * Maven Artifact Factory component.
+     * Used to resolve artifacts using Eclipse Aether.
      */
     @Component
-    protected ArtifactFactory artifactFactory;
+    protected org.eclipse.aether.RepositorySystem artifactResolver;
+
+    
 
     /**
      * Location of the local repository.
@@ -136,10 +137,75 @@ public abstract class AbstractExecWarMojo
     protected ArtifactRepository local;
 
     /**
-     * List of Remote Repositories used by the resolver
+     * List of Remote Repositories used by the resolver.
      */
     @Parameter( defaultValue = "${project.remoteArtifactRepositories}", required = true, readonly = true )
     protected List<ArtifactRepository> remoteRepos;
+
+    protected List<org.eclipse.aether.repository.RemoteRepository> convertToRemoteRepositories( List<ArtifactRepository> mavenRepos )
+    {
+        List<org.eclipse.aether.repository.RemoteRepository> remoteRepos = new ArrayList<>();
+        for ( ArtifactRepository repo : mavenRepos )
+        {
+            remoteRepos.add( new org.eclipse.aether.repository.RemoteRepository.Builder( repo.getId(), "default", repo.getUrl() ).build() );
+        }
+        return remoteRepos;
+    }
+
+    protected Artifact resolveArtifact( String groupId, String artifactId, String version, String type,
+                                        String classifier, String scope )
+        throws MojoExecutionException
+    {
+        try
+        {
+            org.eclipse.aether.artifact.DefaultArtifact aetherArtifact = new org.eclipse.aether.artifact.DefaultArtifact(
+                groupId,
+                artifactId,
+                classifier != null && !classifier.isEmpty() ? classifier : null,
+                type != null && !type.isEmpty() ? type : "jar",
+                version
+            );
+            ArtifactRequest artifactRequest = new ArtifactRequest();
+            artifactRequest.setArtifact( aetherArtifact );
+            artifactRequest.setRepositories( convertToRemoteRepositories( remoteRepos ) );
+
+            org.eclipse.aether.RepositorySystemSession repoSession = new DefaultRepositorySystemSession( session.getRepositorySession() );
+            ArtifactResult result = artifactResolver.resolveArtifact( repoSession, artifactRequest );
+            org.eclipse.aether.artifact.Artifact resolved = result.getArtifact();
+
+            if ( resolved != null && resolved.getFile() != null )
+            {
+                // Use DefaultArtifact to create a Maven Artifact from the resolved info
+                return new DefaultArtifact(
+                    resolved.getGroupId(),
+                    resolved.getArtifactId(),
+                    resolved.getVersion(),
+                    scope != null && !scope.isEmpty() ? scope : Artifact.SCOPE_COMPILE,
+                    resolved.getExtension(),
+                    resolved.getExtension(),
+                    new DefaultArtifactHandler()
+                );
+            }
+        }
+        catch ( ArtifactResolutionException e )
+        {
+            throw new MojoExecutionException( "Unable to resolve artifact: " + groupId + ":" + artifactId
+                + ":" + version, e );
+        }
+
+        return new DefaultArtifact(
+            groupId,
+            artifactId,
+            version,
+            scope != null && !scope.isEmpty() ? scope : Artifact.SCOPE_COMPILE,
+            type != null && !type.isEmpty() ? type : "jar",
+            classifier,
+            new DefaultArtifactHandler()
+        );
+    }
+
+    @Parameter( defaultValue = "${session}", readonly = true, required = true )
+    protected MavenSession session;
 
     @Component
     protected MavenProjectHelper projectHelper;
@@ -324,13 +390,12 @@ public abstract class AbstractExecWarMojo
                                 "Dependency '" + dependency.getGroupId() + "':'" + dependency.getArtifactId()
                                     + "' does not have version specified" );
                         }
-                        Artifact artifact = artifactFactory.createArtifactWithClassifier( dependency.getGroupId(), //
-                                                                                          dependency.getArtifactId(), //
-                                                                                          version, //
-                                                                                          dependency.getType(), //
-                                                                                          dependency.getClassifier() );
-
-                        artifactResolver.resolve( artifact, this.remoteRepos, this.local );
+                        Artifact artifact = resolveArtifact( dependency.getGroupId(), //
+                                                             dependency.getArtifactId(), //
+                                                             version, //
+                                                             dependency.getType(), //
+                                                             dependency.getClassifier(), //
+                                                             null );
 
                         File warFileToBundle = new File( resolvePluginWorkDir(), artifact.getFile().getName() );
                         FileUtils.copyFile( artifact.getFile(), warFileToBundle );
@@ -416,13 +481,12 @@ public abstract class AbstractExecWarMojo
                     }
 
                     // String groupId, String artifactId, String version, String scope, String type
-                    Artifact artifact = artifactFactory.createArtifact( dependency.getGroupId(), //
-                                                                        dependency.getArtifactId(), //
-                                                                        version, //
-                                                                        dependency.getScope(), //
-                                                                        dependency.getType() );
-
-                    artifactResolver.resolve( artifact, this.remoteRepos, this.local );
+                    Artifact artifact = resolveArtifact( dependency.getGroupId(), //
+                                                         dependency.getArtifactId(), //
+                                                         version, //
+                                                         dependency.getType(), //
+                                                         null, //
+                                                         dependency.getScope() );
                     JarFile jarFile = new JarFile( artifact.getFile() );
                     extractJarToArchive( jarFile, os, this.excludes );
                 }
@@ -480,7 +544,7 @@ public abstract class AbstractExecWarMojo
             }
 
         }
-        catch (ManifestException | IOException | ArtifactNotFoundException | ArtifactResolutionException e )
+        catch ( ManifestException | IOException e )
         {
             throw new MojoExecutionException( e.getMessage(), e );
         }

--- a/src/main/java/org/apache/tomcat/maven/plugin/tomcat/run/AbstractRunMojo.java
+++ b/src/main/java/org/apache/tomcat/maven/plugin/tomcat/run/AbstractRunMojo.java
@@ -57,16 +57,10 @@ import org.apache.catalina.startup.CatalinaProperties;
 import org.apache.catalina.startup.Tomcat;
 import org.apache.catalina.valves.AccessLogValve;
 import org.apache.commons.io.IOUtils;
-
 import org.apache.maven.artifact.Artifact;
-import org.apache.maven.artifact.factory.ArtifactFactory;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
 import org.apache.maven.artifact.repository.ArtifactRepository;
-import org.apache.maven.artifact.resolver.ArtifactNotFoundException;
-import org.apache.maven.artifact.resolver.ArtifactResolutionException;
-import org.apache.maven.artifact.resolver.ArtifactResolver;
-import org.apache.maven.artifact.resolver.filter.ScopeArtifactFilter;
-import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
-import org.apache.maven.artifact.versioning.VersionRange;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -91,6 +85,10 @@ import org.codehaus.plexus.classworlds.realm.ClassRealm;
 import org.codehaus.plexus.classworlds.realm.DuplicateRealmException;
 import org.codehaus.plexus.util.DirectoryScanner;
 import org.codehaus.plexus.util.FileUtils;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResult;
 import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
@@ -108,22 +106,22 @@ public abstract class AbstractRunMojo
     // ---------------------------------------------------------------------
 
     /**
-     * Used to look up Artifacts in the remote repository.
+     * Used to resolve artifacts using Eclipse Aether.
      */
     @Component
-    protected ArtifactFactory factory;
+    protected org.eclipse.aether.RepositorySystem repositorySystem;
 
     /**
      * Location of the local repository.
      */
     @Parameter( defaultValue = "${localRepository}", required = true, readonly = true )
-    private ArtifactRepository local;
+    private ArtifactRepository localRepository;
 
     /**
-     * Used to look up Artifacts in the remote repository.
+     * List of Remote Repositories used by the resolver.
      */
-    @Component
-    protected ArtifactResolver resolver;
+    @Parameter( defaultValue = "${project.remoteArtifactRepositories}", required = true, readonly = true )
+    private List<ArtifactRepository> remoteRepos;
 
     // ----------------------------------------------------------------------
     // Mojo Parameters
@@ -1215,13 +1213,13 @@ public abstract class AbstractRunMojo
 
                 portProperties.put( "tomcat.maven.http.port", Integer.toString( connector.getLocalPort() ) );
 
-                session.getExecutionProperties().put( "tomcat.maven.http.port",
+                session.getUserProperties().put( "tomcat.maven.http.port",
                                                       Integer.toString( connector.getLocalPort() ) );
                 System.setProperty( "tomcat.maven.http.port", Integer.toString( connector.getLocalPort() ) );
 
                 if ( httpsConnector != null )
                 {
-                    session.getExecutionProperties().put( "tomcat.maven.https.port",
+                    session.getUserProperties().put( "tomcat.maven.https.port",
                                                           Integer.toString( httpsConnector.getLocalPort() ) );
                     portProperties.put( "tomcat.maven.https.port", Integer.toString( httpsConnector.getLocalPort() ) );
                     System.setProperty( "tomcat.maven.https.port", Integer.toString( httpsConnector.getLocalPort() ) );
@@ -1229,7 +1227,7 @@ public abstract class AbstractRunMojo
 
                 if ( ajpConnector != null )
                 {
-                    session.getExecutionProperties().put( "tomcat.maven.ajp.port",
+                    session.getUserProperties().put( "tomcat.maven.ajp.port",
                                                           Integer.toString( ajpConnector.getLocalPort() ) );
                     portProperties.put( "tomcat.maven.ajp.port", Integer.toString( ajpConnector.getLocalPort() ) );
                     System.setProperty( "tomcat.maven.ajp.port", Integer.toString( ajpConnector.getLocalPort() ) );
@@ -1310,7 +1308,7 @@ public abstract class AbstractRunMojo
 
     public Set<Artifact> getProjectArtifacts()
     {
-        return project.getArtifacts();
+        return project.getDependencyArtifacts();
     }
 
     /**
@@ -1375,14 +1373,13 @@ public abstract class AbstractRunMojo
         // Let's add other modules
         List<Context> contexts = new ArrayList<>();
 
-        ScopeArtifactFilter filter = new ScopeArtifactFilter( "tomcat" );
-        Set<Artifact> artifacts = project.getArtifacts();
+        Set<Artifact> artifacts = project.getDependencyArtifacts();
         for ( Artifact artifact : artifacts )
         {
 
             // Artifact is not yet registered and it has neither test, nor a
             // provided scope, not is it optional
-            if ( "war".equals( artifact.getType() ) && !artifact.isOptional() && filter.include( artifact ) )
+            if ( "war".equals( artifact.getType() ) && !artifact.isOptional() && Artifact.SCOPE_COMPILE.equals( artifact.getScope() ) )
             {
                 addContextFromArtifact( container, contexts, artifact, "/" + artifact.getArtifactId(), null, false );
             }
@@ -1485,46 +1482,62 @@ public abstract class AbstractRunMojo
     protected Artifact getArtifact( Webapp additionalWebapp )
         throws MojoExecutionException
     {
-
-        Artifact artifact;
-        VersionRange vr;
         try
         {
-            vr = VersionRange.createFromVersionSpec( additionalWebapp.getVersion() );
+            ArtifactRequest artifactRequest = new ArtifactRequest();
+            org.eclipse.aether.artifact.Artifact inputArtifact = new org.eclipse.aether.artifact.DefaultArtifact(
+                additionalWebapp.getGroupId(),
+                additionalWebapp.getArtifactId(),
+                additionalWebapp.getClassifier(),
+                additionalWebapp.getType(),
+                additionalWebapp.getVersion()
+            );
+            artifactRequest.setArtifact( inputArtifact );
+            artifactRequest.setRepositories( convertToRemoteRepositories( project.getRemoteArtifactRepositories() ) );
+
+            org.eclipse.aether.RepositorySystemSession repoSession = new DefaultRepositorySystemSession( session.getRepositorySession() );
+            ArtifactResult result = repositorySystem.resolveArtifact( repoSession, artifactRequest );
+            org.eclipse.aether.artifact.Artifact resolvedArtifact = result.getArtifact();
+
+            if ( resolvedArtifact != null && resolvedArtifact.getFile() != null )
+            {
+                return new DefaultArtifact(
+                    resolvedArtifact.getGroupId(),
+                    resolvedArtifact.getArtifactId(),
+                    resolvedArtifact.getVersion(),
+                    Artifact.SCOPE_COMPILE,
+                    resolvedArtifact.getExtension(),
+                    resolvedArtifact.getClassifier(),
+new DefaultArtifactHandler()
+                );
+            }
         }
-        catch ( InvalidVersionSpecificationException e )
+        catch ( org.eclipse.aether.resolution.ArtifactResolutionException e )
         {
-            getLog().warn( "fail to create versionRange from version: " + additionalWebapp.getVersion(), e );
-            vr = VersionRange.createFromVersion( additionalWebapp.getVersion() );
+            throw new MojoExecutionException( "Unable to resolve artifact: " + additionalWebapp.getGroupId()
+                + ":" + additionalWebapp.getArtifactId() + ":" + additionalWebapp.getVersion(), e );
         }
 
-        if ( additionalWebapp.getClassifier() == null || additionalWebapp.getClassifier().isEmpty() )
-        {
-            artifact =
-                factory.createDependencyArtifact( additionalWebapp.getGroupId(), additionalWebapp.getArtifactId(), vr,
-                                                  additionalWebapp.getType(), null, Artifact.SCOPE_COMPILE );
-        }
-        else
-        {
-            artifact =
-                factory.createDependencyArtifact( additionalWebapp.getGroupId(), additionalWebapp.getArtifactId(), vr,
-                                                  additionalWebapp.getType(), additionalWebapp.getClassifier(),
-                                                  Artifact.SCOPE_COMPILE );
-        }
-
-        try
-        {
-            resolver.resolve( artifact, project.getRemoteArtifactRepositories(), this.local );
-        }
-        catch ( ArtifactResolutionException e )
-        {
-            throw new MojoExecutionException( "Unable to resolve artifact.", e );
-        }
-        catch ( ArtifactNotFoundException e )
-        {
-            throw new MojoExecutionException( "Unable to find artifact.", e );
-        }
-
-        return artifact;
+        return new DefaultArtifact(
+            additionalWebapp.getGroupId(),
+            additionalWebapp.getArtifactId(),
+            additionalWebapp.getVersion(),
+            Artifact.SCOPE_COMPILE,
+            additionalWebapp.getType(),
+            additionalWebapp.getClassifier(),
+new DefaultArtifactHandler()
+        );
     }
+
+    private List<RemoteRepository> convertToRemoteRepositories( List<ArtifactRepository> mavenRepos )
+    {
+        List<RemoteRepository> remoteRepos = new ArrayList<>();
+        for ( ArtifactRepository repo : mavenRepos )
+        {
+            remoteRepos.add( new RemoteRepository.Builder( repo.getId(), "default", repo.getUrl() ).build() );
+        }
+        return remoteRepos;
+    }
+
+    
 }

--- a/src/main/java/org/apache/tomcat/maven/plugin/tomcat/run/AbstractStandaloneWarMojo.java
+++ b/src/main/java/org/apache/tomcat/maven/plugin/tomcat/run/AbstractStandaloneWarMojo.java
@@ -32,8 +32,6 @@ import org.apache.commons.compress.archivers.jar.JarArchiveEntry;
 import org.apache.commons.io.IOUtils;
 
 import org.apache.maven.artifact.Artifact;
-import org.apache.maven.artifact.resolver.ArtifactNotFoundException;
-import org.apache.maven.artifact.resolver.ArtifactResolutionException;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -204,13 +202,12 @@ public abstract class AbstractStandaloneWarMojo
                                 + "' does not have version specified" );
                     }
                     // String groupId, String artifactId, String version, String scope, String type
-                    Artifact artifact = artifactFactory.createArtifact( dependency.getGroupId(), //
-                                                                        dependency.getArtifactId(), //
-                                                                        version, //
-                                                                        dependency.getScope(), //
-                                                                        dependency.getType() );
-
-                    artifactResolver.resolve( artifact, this.remoteRepos, this.local );
+                    Artifact artifact = resolveArtifact( dependency.getGroupId(), //
+                                                         dependency.getArtifactId(), //
+                                                         version, //
+                                                         dependency.getType(), //
+                                                         null, //
+                                                         dependency.getScope() );
                     JarFile jarFile = new JarFile( artifact.getFile() );
                     extractJarToArchive( jarFile, os, excludes );
                 }
@@ -272,14 +269,6 @@ public abstract class AbstractStandaloneWarMojo
             throw new MojoExecutionException( e.getMessage(), e );
         }
         catch ( IOException e )
-        {
-            throw new MojoExecutionException( e.getMessage(), e );
-        }
-        catch ( ArtifactNotFoundException e )
-        {
-            throw new MojoExecutionException( e.getMessage(), e );
-        }
-        catch ( ArtifactResolutionException e )
         {
             throw new MojoExecutionException( e.getMessage(), e );
         }

--- a/src/main/java/org/apache/tomcat/maven/plugin/tomcat/run/RunMojo.java
+++ b/src/main/java/org/apache/tomcat/maven/plugin/tomcat/run/RunMojo.java
@@ -191,7 +191,7 @@ public class RunMojo
             temporaryContextFile = File.createTempFile( "tomcat-maven-plugin", "temp-ctx-file" );
             temporaryContextFile.deleteOnExit();
 
-            // format to modify/create <Context backgroundProcessorDelay="5" reloadable="false">
+// format to modify/create <Context backgroundProcessorDelay="5" reloadable="false">
             if ( contextFile != null && contextFile.exists() )
             {
                 MavenFileFilterRequest mavenFileFilterRequest = new MavenFileFilterRequest();
@@ -283,6 +283,7 @@ public class RunMojo
                 .setDependencies( dependencies ) //
                 .setLog( getLog() ) //
                 .setMavenProject( project ) //
+                .setMavenSession( session ) //
                 .setAddWarDependenciesInClassloader( addWarDependenciesInClassloader ) //
                 .setUseTestClassPath( useTestClasspath );
             final ClassLoaderEntriesCalculatorResult classLoaderEntriesCalculatorResult =

--- a/src/main/java/org/apache/tomcat/maven/plugin/tomcat/run/RunMojo.java
+++ b/src/main/java/org/apache/tomcat/maven/plugin/tomcat/run/RunMojo.java
@@ -283,7 +283,6 @@ public class RunMojo
                 .setDependencies( dependencies ) //
                 .setLog( getLog() ) //
                 .setMavenProject( project ) //
-                .setMavenSession( session ) //
                 .setAddWarDependenciesInClassloader( addWarDependenciesInClassloader ) //
                 .setUseTestClassPath( useTestClasspath );
             final ClassLoaderEntriesCalculatorResult classLoaderEntriesCalculatorResult =


### PR DESCRIPTION
Mostly authored by OpenCode, with lots of cleanups. @Component is now deprecated, but it should still be used. Add support for an encrypted config.
MavenProject.getDependencyArtifacts() was deprecated a long time ago along with the setter. This should still be used.